### PR TITLE
Simplified Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@
 
 CFLAGS+=-pthread -O2
 
-all: fiche.c
-	$(CC) -o fiche $(CFLAGS) fiche.c
+all: fiche
 
 install: fiche
 	install -m 0755 fiche ${PREFIX}/bin


### PR DESCRIPTION
You don't need to state compile commands explicitly. Tested with GNU Make and BSD Make: works exactly the same way.
```
% make
  cc -O2 -pipe   -pthread -O2  fiche.c  -o fiche
% make clean
  rm -f fiche
% gmake
  cc -pthread -O2    fiche.c   -o fiche
% gmake clean
  rm -f fiche
```