### PR TITLE
Move /bin suffix to $prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 # for debug add -g -O0 to line below
 CFLAGS+=-pthread -O2 -Wall -Wextra -Wpedantic -Wstrict-overflow -fno-strict-aliasing -std=gnu11 -g -O0
-prefix=/usr/local
+prefix=/usr/local/bin
 
 all:
 	${CC} main.c fiche.c $(CFLAGS) -o fiche
 
 install: fiche
-	install -m 0755 fiche $(prefix)/bin
+	install -m 0755 fiche $(prefix)
 
 clean:
 	rm -f fiche


### PR DESCRIPTION
This makes it a lot more portable. For example, on NixOS, there is no `bin` directory.