### PR TITLE
Update Makefile for building standard and debug symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # ignore binaries
 /fiche
 
-# ignore default output dir
+# ignore default outpit dir
 code/
 
 # ignore log files

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 # ignore binaries
 /fiche
+
+# ignore default output dir
+code/
+
+# ignore log files
+*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,21 @@
 language: c
-script: make
+
+compiler:
+  - gcc
+  - clang
+
+addons:
+  apt:
+    packages:
+      - cppcheck
+      - clang-3.5
+
+install:
+  - export PYTHONUSERBASE=~/.local
+  - easy_install --user scan-build
+  - easy_install --user typing
+
+script:
+  - cppcheck --enable=all --error-exitcode=1 --inconclusive main.c fiche.c
+  - make
+  - scan-build --status-bugs make -B

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,29 @@
-# for debug add -g -O0 to line below
-CFLAGS+=-pthread -O2 -Wall -Wextra -Wpedantic -Wstrict-overflow -fno-strict-aliasing -std=gnu11 -g -O0
-prefix=/usr/local/bin
+TARGET = fiche
+CFLAGS += -pthread -O2 -Wall -Wextra -Wpedantic -Wstrict-overflow -fno-strict-aliasing -std=gnu11
+PREFIX = /usr/local/bin
+LIBS = -lm
 
-all:
-	${CC} main.c fiche.c $(CFLAGS) -o fiche
+OBJECTS = $(patsubst %.c, %.o, $(wildcard *.c))
+HEADERS = $(wildcard *.h)
 
-install: fiche
-	install -m 0755 fiche $(prefix)
+.PHONY: all install debug clean
+
+default: all
+
+all: $(TARGET)
+
+%.o: %.c $(HEADERS)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(TARGET): $(OBJECTS)
+	${CC} $(OBJECTS) $(CFLAGS) $(LIBS) -o $@
+
+debug: CFLAGS += -g -O0
+debug: $(TARGET)
+
+install: $(TARGET)
+	install -m 0755 $(TARGET) $(PREFIX)
 
 clean:
-	rm -f fiche
-
-.PHONY: clean
+	$(RM) *.o
+	$(RM) $(TARGET)


### PR DESCRIPTION
Allow for choice of stripped executable or debug executable.

`make` defaults to `all`. 
`all` builds executable

`make debug` adds in debug symbols

`fiche` with debug = 33k size executable
`fiche` without is 19k size executable