### PR TITLE
Add `-a` Anonymous mode. No URL is returned, only a token.

### DIFF
--- a/fiche.c
+++ b/fiche.c
@@ -370,7 +370,6 @@ static int set_domain_name(Fiche_Settings *settings) {
         prefix = "http://";
         }
     } else {
-        prefix = "";
         print_status("Domain is unset.");
         return 0;
     }

--- a/fiche.c
+++ b/fiche.c
@@ -363,23 +363,28 @@ static void get_date(char *buf) {
 static int set_domain_name(Fiche_Settings *settings) {
 
     char *prefix = "";
-    if (settings->https) {
-        prefix = "https://";
-    } else {
+    if (settings->domain) {
+        if (settings->https) {
+            prefix = "https://";
+        } else {
         prefix = "http://";
+        }
+    } else {
+        prefix = "";
+        print_status("Domain is unset.");
+        return 0;
     }
     const int len = strlen(settings->domain) + strlen(prefix) + 1;
 
     char *b = malloc(len);
     if (!b) {
-        return -1;
+       return -1;
     }
 
     strcpy(b, prefix);
     strcat(b, settings->domain);
 
     settings->domain = b;
-
     print_status("Domain set to: %s.", settings->domain);
 
     return 0;
@@ -653,11 +658,14 @@ static void *handle_connection(void *args) {
     // Write a response to the user
     {
         // Create an url (additional byte for slash and one for new line)
-        const size_t len = strlen(c->settings->domain) + strlen(slug) + 3;
+        const size_t len = (c->settings->domain) ? strlen(c->settings->domain) + strlen(slug) + 3 : strlen(slug) + 2;
 
         char url[len];
-        snprintf(url, len, "%s%s%s%s", c->settings->domain, "/", slug, "\n");
-
+        if (c->settings->domain) {
+            snprintf(url, len, "%s%s%s%s", c->settings->domain, "/", slug, "\n");
+        } else {
+            snprintf(url, len, "%s%s", slug, "\n");
+        }
         // Send the response
         write(c->socket, url, len);
     }

--- a/main.c
+++ b/main.c
@@ -44,13 +44,20 @@ int main(int argc, char **argv) {
 
     // Parse input arguments
     int c;
-    while ((c = getopt(argc, argv, "D6eSp:b:s:d:o:l:B:u:w:")) != -1) {
+    while ((c = getopt(argc, argv, "D6heSad:p:b:s:o:l:B:u:w:")) != -1) {
         switch (c) {
 
             // domain
             case 'd':
             {
                 fs.domain = optarg;
+            }
+            break;
+
+            // anonymous mode
+            case 'a':
+            {
+                fs.domain = NULL;
             }
             break;
 
@@ -117,7 +124,8 @@ int main(int argc, char **argv) {
             }
             break;
 
-            // Display help in case of any unsupported argument
+            // Display help in case of any unsupported argument or help
+            case 'h':
             default:
             {
                 printf("usage: fiche [-dpsSoBulbw].\n");


### PR DESCRIPTION
Adds the ability to return only a token and not a URL. 

We use this to have users submit log information for review. We do not allow users to view other users logs, so the log aggregation is isolated. The users provide us with the slug and we review their logs for troubleshooting information.

Signed-off-by: Dan Schaper <dan.schaper@pi-hole.net>