### PR TITLE
teach fiche about binding to a specific address

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ To use fiche you have to have netcat installed. You probably already have it - t
 
 ```
 usage: fiche [-D6epbsdSolBuw].
-             [-d domain] [-p port] [-s slug size]
+             [-d domain] [-L listen_addr ] [-p port] [-s slug size]
              [-o output directory] [-B buffer size] [-u user name]
              [-l log file] [-b banlist] [-w whitelist] [-S]
 ```

--- a/fiche.c
+++ b/fiche.c
@@ -197,6 +197,8 @@ void fiche_init(Fiche_Settings *settings) {
         "example.com",
         // output dir
         "code",
+	// listen_addr
+	"0.0.0.0",
         // port
         9999,
         // slug length
@@ -442,7 +444,7 @@ static int start_server(Fiche_Settings *settings) {
     // Prepare address and port handler
     struct sockaddr_in address;
     address.sin_family = AF_INET;
-    address.sin_addr.s_addr = INADDR_ANY;
+    address.sin_addr.s_addr = inet_addr(settings->listen_addr);
     address.sin_port = htons(settings->port);
 
     // Bind to port
@@ -457,7 +459,8 @@ static int start_server(Fiche_Settings *settings) {
         return -1;
     }
 
-    print_status("Server started listening on port: %d.", settings->port);
+    print_status("Server started listening on: %s:%d.",
+		    settings->listen_addr, settings->port);
     print_separator();
 
     // Run dispatching loop

--- a/fiche.h
+++ b/fiche.h
@@ -44,6 +44,11 @@ typedef struct Fiche_Settings {
     char *output_dir_path;
 
     /**
+     * @brief Address on which fiche is waiting for connections
+     */
+    char *listen_addr;
+
+    /**
      * @brief Port on which fiche is waiting for connections
      */
     uint16_t port;

--- a/main.c
+++ b/main.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
 
     // Parse input arguments
     int c;
-    while ((c = getopt(argc, argv, "D6eSp:b:s:d:o:l:B:u:w:")) != -1) {
+    while ((c = getopt(argc, argv, "D6eSL:p:b:s:d:o:l:B:u:w:")) != -1) {
         switch (c) {
 
             // domain
@@ -58,6 +58,13 @@ int main(int argc, char **argv) {
             case 'p':
             {
                 fs.port = atoi(optarg);
+            }
+            break;
+
+            // listen_addr
+            case 'L':
+            {
+                fs.listen_addr = optarg;
             }
             break;
 
@@ -120,8 +127,8 @@ int main(int argc, char **argv) {
             // Display help in case of any unsupported argument
             default:
             {
-                printf("usage: fiche [-dpsSoBulbw].\n");
-                printf("             [-d domain] [-p port] [-s slug size]\n");
+                printf("usage: fiche [-dLpsSoBulbw].\n");
+                printf("             [-d domain] [-L listen_addr] [-p port] [-s slug size]\n");
                 printf("             [-o output directory] [-B buffer size] [-u user name]\n");
                 printf("             [-l log file] [-b banlist] [-w whitelist] [-S]\n");
                 return 0;


### PR DESCRIPTION
Add the -L <listen_addr> option which permits fiche to bind to a
specific local address rather than INADDR_ANY.