### PR TITLE
Ease the packaging process for openSUSE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 # for debug add -g -O0 to line below
 CFLAGS+=-pthread -O2 -Wall -Wextra -Wpedantic -Wstrict-overflow -fno-strict-aliasing -std=gnu11 -g -O0
-prefix=/usr/local/bin
+DESTDIR?=
+PREFIX?=/usr/local/bin
 
 all:
 	${CC} main.c fiche.c $(CFLAGS) -o fiche
 
 install: fiche
-	install -m 0755 fiche $(prefix)
+	install -d $(DESTDIR)$(PREFIX)
+	install -m 0755 fiche $(DESTDIR)$(PREFIX)
 
 clean:
 	rm -f fiche

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ all:
 install: fiche
 	install -d $(DESTDIR)$(PREFIX)
 	install -m 0755 fiche $(DESTDIR)$(PREFIX)
+	install -d $(DESTDIR)/usr/lib/systemd/system
+	install -m 644 extras/systemd.fiche@.service $(DESTDIR)/usr/lib/systemd/system/fiche@.service
 
 clean:
 	rm -f fiche

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ To use fiche you have to have netcat installed. You probably already have it - t
     sudo make install
     ```
 
+Note: Adding `PREFIX=/path/to/directory` can override the default /usr/local/bin installation prefix, adittionally `DESTDIR` can also be set, and will be prepended
 ### Using Ports on FreeBSD
 
 To install the port: `cd /usr/ports/net/fiche/ && make install clean`. To add the package: `pkg install fiche`.

--- a/extras/packaging/fiche.spec
+++ b/extras/packaging/fiche.spec
@@ -1,0 +1,66 @@
+#
+# spec file for package fiche
+#
+# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+Name:           fiche
+Version:        0.9.1+git.20181220
+Release:        0
+Summary:        Command line pastebin for sharing terminal output
+License:        MIT
+Group:          Productivity/Office/Other
+Url:            http://termbin.com
+Source:         %{name}-%{version}.tar.xz
+Patch0:         0001-Allow-override-of-the-prefix-variable.patch
+Patch1:         0002-Add-systemd-unit-and-fiche-user.patch
+Requires:       netcat
+
+%description
+Fiche it's a command line pastebin service for sharing terminal output,
+after setting it up, it becomes quite easy to use as 'command | nc <ip> <port>'
+which returns an url that you can easily use in another machine.
+
+%prep
+%setup -q
+%patch0 -p1
+%patch1 -p1
+
+%build
+%make_build
+
+%install
+%make_install PREFIX=%{_bindir}
+
+%pre
+if ! getent passwd fiche > /dev/null; then
+  %{_sbindir}/useradd -r -g nogroup -c "Fiche user" \
+    -d %{_localstatedir}/lib/fiche fiche 2>/dev/null || :
+fi
+
+%post
+if [ ! -e %{_localstatedir}/log/fiche ]; then
+        install -d 0644 -o %{name} %{_localstatedir}/log/fiche || :
+fi
+
+
+%files
+%defattr(-,root,root)
+%{_bindir}/%{name}
+%license LICENSE
+%doc README.md
+%{_unitdir}/%{name}@.service
+
+%changelog
+

--- a/extras/systemd.fiche@.service
+++ b/extras/systemd.fiche@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Fiche server
+Wants=network.target
+After=network.target
+
+[Service]
+ExecStartPre=/usr/bin/install -d -m 0755 -o fiche /var/lib/fiche/%i
+ExecStart=/usr/bin/fiche -d %i -o /var/lib/fiche/%i -l /var/log/fiche/%i.log -u fiche
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hi!

While packaging fiche for [openSUSE](https://build.opensuse.org/package/show/home:szarate/fiche), I came across the small problem that it's not easy to overwrite the prefix.

I went a bit further ahead and added a systemd-unit file that will create a fiche user and the .spec file that I'm using to package it.

Suggestions are welcome :) (I'm not a Makefile expert :dancer: ), ~~I'll work later on adding the service files necessary~~

nginx configuration would be the next step