### PR TITLE
Remove the VLA from handle_connection()

### DIFF
--- a/fiche.c
+++ b/fiche.c
@@ -664,8 +664,6 @@ exit:
     free(slug);
     free(c);
 
-    pthread_exit(NULL);
-
     return NULL;
 }
 

--- a/fiche.c
+++ b/fiche.c
@@ -534,6 +534,7 @@ static void dispatch_connection(int socket, Fiche_Settings *settings) {
 
 
 static void *handle_connection(void *args) {
+    char *slug = NULL;
 
     // Cast args to it's previous type
     struct fiche_connection *c = (struct fiche_connection *) args;
@@ -569,14 +570,7 @@ static void *handle_connection(void *args) {
         print_error("No data received from the client!");
         print_separator();
 
-        // Close the socket
-        close(c->socket);
-
-        // Cleanup
-        free(c);
-        pthread_exit(NULL);
-
-        return 0;
+        goto exit;
     }
 
     // - Check if request was performed with a known protocol
@@ -589,7 +583,6 @@ static void *handle_connection(void *args) {
     // TODO
 
     // Generate slug and use it to create an url
-    char *slug;
     uint8_t extra = 0;
 
     do {
@@ -613,12 +606,7 @@ static void *handle_connection(void *args) {
             print_error("Couldn't generate a valid slug!");
             print_separator();
 
-            // Cleanup
-            free(c);
-            free(slug);
-            close(c->socket);
-            pthread_exit(NULL);
-            return NULL;
+            goto exit;
         }
 
     }
@@ -630,12 +618,7 @@ static void *handle_connection(void *args) {
         print_error("Couldn't generate a slug!");
         print_separator();
 
-        close(c->socket);
-
-        // Cleanup
-        free(c);
-        pthread_exit(NULL);
-        return NULL;
+        goto exit;
     }
 
 
@@ -644,13 +627,7 @@ static void *handle_connection(void *args) {
         print_error("Couldn't save a file!");
         print_separator();
 
-        close(c->socket);
-
-        // Cleanup
-        free(c);
-        free(slug);
-        pthread_exit(NULL);
-        return NULL;
+        goto exit;
     }
 
     // Write a response to the user
@@ -672,6 +649,7 @@ static void *handle_connection(void *args) {
     // TODO: log unsuccessful and rejected connections
     log_entry(c->settings, ip, hostname, slug);
 
+exit:
     // Close the connection
     close(c->socket);
 


### PR DESCRIPTION
This fixes a segfault on musl libc with reasonable sized buffers, as
musl's default thread stack size is quite small (128k since 1.1.21).
    
A similar bug exists on glibc with large enough buffers (reproducable
with e.g. 16MB on my test system).

This fixes #108.