### PR TITLE
Add illumos support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,26 @@
+OS := $(shell uname -o)
+ifeq ($(OS),illumos)
 # for debug add -g -O0 to line below
-CFLAGS+=-pthread -O2 -Wall -Wextra -Wpedantic -Wstrict-overflow -fno-strict-aliasing -std=gnu11 -g -O0
-prefix=/usr/local/bin
+    CFLAGS+=-pthread -O2 -Wall -Wextra -Wpedantic -Wstrict-overflow -fno-strict-aliasing -std=gnu11 -lsocket  -lnsl
+    prefix=/opt/local/bin
+
+all:
+	${CC} main.c fiche.c $(CFLAGS) -o fiche
+
+install: fiche
+	install  -m 0755 fiche $(prefix)
+	svccfg import fiche.xml
+else
+# for debug add -g -O0 to line below
+    CFLAGS+=-pthread -O2 -Wall -Wextra -Wpedantic -Wstrict-overflow -fno-strict-aliasing -std=gnu11 -g -O0
+    prefix=/usr/local/bin
 
 all:
 	${CC} main.c fiche.c $(CFLAGS) -o fiche
 
 install: fiche
 	install -m 0755 fiche $(prefix)
+endif
 
 clean:
 	rm -f fiche

--- a/fiche.xml
+++ b/fiche.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+        Created by Manifold
+--><service_bundle type="manifest" name="fiche">
+
+    <service name="network/fiche" type="service" version="1">
+
+        <create_default_instance enabled="false"/>
+        
+        <single_instance/>
+
+        <dependency name="network" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/milestone/network:default"/>
+        </dependency>
+
+        <dependency name="filesystem" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/system/filesystem/local"/>
+        </dependency>
+
+        
+        <method_context>
+            <method_credential user="fiche" />
+        </method_context>
+
+        <exec_method type="method" name="start" exec="/opt/local/bin/fiche -S -o /home/fiche/code -d example.com -l /var/log/fiche.log -s 6 " timeout_seconds="60"/>
+
+        <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60"/>
+
+        <property_group name="startd" type="framework">
+            <propval name="duration" type="astring" value="child"/>
+            
+            
+            <propval name="ignore_error" type="astring" value="core,signal"/>
+        </property_group>
+
+        <property_group name="application" type="application">
+            
+        </property_group>
+        
+        
+        <stability value="Evolving"/>
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">
+                    fiche
+                </loctext>
+            </common_name>
+        </template>
+
+    </service>
+
+</service_bundle>


### PR DESCRIPTION
Currently I'm using [SmartOS](https://www.joyent.com/smartos) a derivative of [illumos](https://en.wikipedia.org/wiki/Illumos) to selfhost my home datacenter and fiche is running great on it,so here is what I did to make it work on illumos.
Thanks for fiche is really great!.