### PR TITLE
Bugfix: use after free

### DIFF
--- a/fiche.c
+++ b/fiche.c
@@ -614,9 +614,9 @@ static void *handle_connection(void *args) {
             print_separator();
 
             // Cleanup
+            close(c->socket);
             free(c);
             free(slug);
-            close(c->socket);
             pthread_exit(NULL);
             return NULL;
         }


### PR DESCRIPTION
This was detected by cc:

cc main.c fiche.c -pthread -O2 -Wall -Wextra -Wpedantic -Wstrict-overflow -fno-strict-aliasing -std=gnu11 -g -O0 -o fiche fiche.c: In function 'handle_connection':
fiche.c:619:13: warning: pointer 'c' used after 'free' [-Wuse-after-free]
  619 |             close(c->socket);
      |             ^~~~~~~~~~~~~~~~
fiche.c:617:13: note: call to 'free' here
  617 |             free(c);
      |             ^~~~~~~
paste:~/src/fiche$ ls


$ cc --version
cc (Alpine 13.1.1_git20230708) 13.1.1 20230708
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.